### PR TITLE
Add each controller with a different name

### DIFF
--- a/topo.py
+++ b/topo.py
@@ -50,6 +50,7 @@ def run( controllers ):
     ctrl_count = 0
     for controllerIP in controllers:
         net.addController( 'c%d' % ctrl_count, RemoteController, ip=controllerIP )
+        ctrl_count += 1
     net.start()
     CLI( net )
     net.stop()


### PR DESCRIPTION
Using the same name for all seems to prevent the switches from being created.
